### PR TITLE
Add resetInfo to printSystemInfo

### DIFF
--- a/PlantModule/Utils.cpp
+++ b/PlantModule/Utils.cpp
@@ -39,6 +39,8 @@ void printSystemInfo() {
   Serial.println(ESP.getFreeSketchSpace());
   Serial.print("ResetReason           : ");
   Serial.println(ESP.getResetReason());
+  Serial.print(F("ResetInfo             : "));
+  Serial.println(ESP.getResetInfo());
   Serial.println("----- IP details ---------------------------------------------");
   Serial.print("IP Address            : ");
   Serial.println(WiFi.localIP());


### PR DESCRIPTION
Example output:
ResetReason           : Hardware Watchdog
ResetInfo             : Fatal exception:4 flag:1 (WDT) epc1:0x4010606b epc2:0x00000000 epc3:0x00000000 excvaddr:0x00000000 depc:0x00000000
